### PR TITLE
release: bump web-eid-authtoken-validation-dotnet version to 1.1.0

### DIFF
--- a/src/WebEid.AspNetCore.Example/WebEid.AspNetCore.Example.csproj
+++ b/src/WebEid.AspNetCore.Example/WebEid.AspNetCore.Example.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.15.1" />
     <PackageReference Include="System.Runtime.Caching" Version="6.0.0" />
     <PackageReference Include="System.Text.Json" Version="6.0.3" />
-    <PackageReference Include="WebEid.Security" Version="1.0.0" />
+    <PackageReference Include="WebEid.Security" Version="1.1.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
WE2-838

Signed-off-by: Mart Somermaa <mrts@users.noreply.github.com>
