### PR TITLE
Fixed race condition with digidoc initialize/terminate

### DIFF
--- a/src/WebEid.AspNetCore.Example/Controllers/Api/AuthController.cs
+++ b/src/WebEid.AspNetCore.Example/Controllers/Api/AuthController.cs
@@ -47,6 +47,10 @@
                 CookieAuthenticationDefaults.AuthenticationScheme,
                 new ClaimsPrincipal(claimsIdentity),
                 authProperties);
+            
+            // Assign a unique ID within the session to enable the use of a unique temporary container name across successive requests.
+            // A unique temporary container name is required to facilitate simultaneous signing from multiple browsers.
+            SetUniqueIdInSession();
         }
 
         [HttpGet]

--- a/src/WebEid.AspNetCore.Example/Controllers/Api/BaseController.cs
+++ b/src/WebEid.AspNetCore.Example/Controllers/Api/BaseController.cs
@@ -1,21 +1,31 @@
 ﻿namespace WebEid.AspNetCore.Example.Controllers.Api
 {
-    using System.Security;
-    using System.Security.Claims;
+    using System;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
 
     public abstract class BaseController : ControllerBase
     {
+        const string uniqueIdKey = "UniqueId";
+
         protected void RemoveUserContainerFile()
         {
             System.IO.File.Delete(GetUserContainerName());
         }
 
+        protected void SetUniqueIdInSession() 
+        {
+            HttpContext.Session.SetString(uniqueIdKey, Guid.NewGuid().ToString());
+        }
+
+        private string GetUniqueIdFromSession() 
+        {
+            return HttpContext.Session.GetString(uniqueIdKey);
+        }
+
         protected string GetUserContainerName()
         {
-            var identity = (ClaimsIdentity)this.HttpContext.User?.Identity ??
-                           throw new SecurityException("User is not logged in");
-            return identity.GetIdCode();
+            return $"container_{GetUniqueIdFromSession()}";
         }
     }
 }

--- a/src/WebEid.AspNetCore.Example/Controllers/Api/SignController.cs
+++ b/src/WebEid.AspNetCore.Example/Controllers/Api/SignController.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Security.Claims;
     using System.Threading.Tasks;
-    using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Logging;
     using Services;

--- a/src/WebEid.AspNetCore.Example/Signing/SigningService.cs
+++ b/src/WebEid.AspNetCore.Example/Signing/SigningService.cs
@@ -74,21 +74,21 @@
             throw new ArgumentException("Supported signature algorithm not found");
         }
 
-        private static bool FragmentEquals(string framgent, SignatureAlgorithmDto signatureAlgorithm) =>
+        private static bool FragmentEquals(string fragment, SignatureAlgorithmDto signatureAlgorithm) =>
             signatureAlgorithm switch
             {
-                { CryptoAlgorithm: "ECC", PaddingScheme: "NONE", HashFunction: "SHA-224" } => framgent == "#ecdsa-sha224",
-                { CryptoAlgorithm: "ECC", PaddingScheme: "NONE", HashFunction: "SHA-256" } => framgent == "#ecdsa-sha256",
-                { CryptoAlgorithm: "ECC", PaddingScheme: "NONE", HashFunction: "SHA-384" } => framgent == "#ecdsa-sha384",
-                { CryptoAlgorithm: "ECC", PaddingScheme: "NONE", HashFunction: "SHA-512" } => framgent == "#ecdsa-sha512",
-                { CryptoAlgorithm: "RSA", PaddingScheme: "PKCS1.5", HashFunction: "SHA-224" } => framgent == "#rsa-sha224",
-                { CryptoAlgorithm: "RSA", PaddingScheme: "PKCS1.5", HashFunction: "SHA-256" } => framgent == "#rsa-sha256",
-                { CryptoAlgorithm: "RSA", PaddingScheme: "PKCS1.5", HashFunction: "SHA-384" } => framgent == "#rsa-sha384",
-                { CryptoAlgorithm: "RSA", PaddingScheme: "PKCS1.5", HashFunction: "SHA-512" } => framgent == "#rsa-sha512",
-                { CryptoAlgorithm: "RSA", PaddingScheme: "PSS", HashFunction: "SHA-224" } => framgent == "#sha224-rsa-MGF1",
-                { CryptoAlgorithm: "RSA", PaddingScheme: "PSS", HashFunction: "SHA-256" } => framgent == "#sha256-rsa-MGF1",
-                { CryptoAlgorithm: "RSA", PaddingScheme: "PSS", HashFunction: "SHA-384" } => framgent == "#sha384-rsa-MGF1",
-                { CryptoAlgorithm: "RSA", PaddingScheme: "PSS", HashFunction: "SHA-512" } => framgent == "#sha512-rsa-MGF1",
+                { CryptoAlgorithm: "ECC", PaddingScheme: "NONE", HashFunction: "SHA-224" } => fragment == "#ecdsa-sha224",
+                { CryptoAlgorithm: "ECC", PaddingScheme: "NONE", HashFunction: "SHA-256" } => fragment == "#ecdsa-sha256",
+                { CryptoAlgorithm: "ECC", PaddingScheme: "NONE", HashFunction: "SHA-384" } => fragment == "#ecdsa-sha384",
+                { CryptoAlgorithm: "ECC", PaddingScheme: "NONE", HashFunction: "SHA-512" } => fragment == "#ecdsa-sha512",
+                { CryptoAlgorithm: "RSA", PaddingScheme: "PKCS1.5", HashFunction: "SHA-224" } => fragment == "#rsa-sha224",
+                { CryptoAlgorithm: "RSA", PaddingScheme: "PKCS1.5", HashFunction: "SHA-256" } => fragment == "#rsa-sha256",
+                { CryptoAlgorithm: "RSA", PaddingScheme: "PKCS1.5", HashFunction: "SHA-384" } => fragment == "#rsa-sha384",
+                { CryptoAlgorithm: "RSA", PaddingScheme: "PKCS1.5", HashFunction: "SHA-512" } => fragment == "#rsa-sha512",
+                { CryptoAlgorithm: "RSA", PaddingScheme: "PSS", HashFunction: "SHA-224" } => fragment == "#sha224-rsa-MGF1",
+                { CryptoAlgorithm: "RSA", PaddingScheme: "PSS", HashFunction: "SHA-256" } => fragment == "#sha256-rsa-MGF1",
+                { CryptoAlgorithm: "RSA", PaddingScheme: "PSS", HashFunction: "SHA-384" } => fragment == "#sha384-rsa-MGF1",
+                { CryptoAlgorithm: "RSA", PaddingScheme: "PSS", HashFunction: "SHA-512" } => fragment == "#sha512-rsa-MGF1",
                 _ => false
             };
         

--- a/src/WebEid.AspNetCore.Example/Signing/SigningService.cs
+++ b/src/WebEid.AspNetCore.Example/Signing/SigningService.cs
@@ -23,9 +23,9 @@
             this.configuration = configuration;
             this.logger = logger;
             
-            // Current implementation of static digidoc assumes that SigningService is used as singleton
-            // in ASP.NET Core application we initialize it with AddSingleton method in Startup.cs
-            // digidoc is initialized in constructor and terminated in Dispose
+            // The current implementation of the static DigiDoc library assumes that SigningService is used as a singleton.
+            // In the ASP.NET Core application, we initialize it using the AddSingleton method in Startup.cs.
+            // The DigiDoc library is initialized in the constructor and terminated in Dispose.
             configuration.Initialize();
             digidoc.initialize("WebEidExample");
         }
@@ -104,7 +104,9 @@
         {
             if (!_disposedValue)
             {
-                if (disposing) {}
+                if (disposing) {
+                    // You can release managed resources here if needed.
+                }
 
                 digidoc.terminate();
                 _disposedValue = true;

--- a/src/WebEid.AspNetCore.Example/Signing/SigningService.cs
+++ b/src/WebEid.AspNetCore.Example/Signing/SigningService.cs
@@ -22,7 +22,7 @@
         {
             this.configuration = configuration;
             this.logger = logger;
-            
+
             // The current implementation of the static DigiDoc library assumes that SigningService is used as a singleton.
             // In the ASP.NET Core application, we initialize it using the AddSingleton method in Startup.cs.
             // The DigiDoc library is initialized in the constructor and terminated in Dispose.
@@ -38,14 +38,14 @@
                 throw new ArgumentException(
                     "Authenticated subject ID code differs from signing certificate subject ID code");
             }
-            
+
             this.logger?.LogDebug("Creating container file: '{0}'", tempContainerName);
             Container container = Container.create(tempContainerName);
             container.addDataFile(FileToSign, "application/octet-stream");
             logger?.LogInformation("Preparing container for signing for file '{0}'", tempContainerName);
             var signature =
                 container.prepareWebSignature(certificate.Export(X509ContentType.Cert), "time-stamp");
-                var hashFunction = GetSupportedHashAlgorithm(data.SupportedSignatureAlgorithms, signature.signatureMethod());
+            var hashFunction = GetSupportedHashAlgorithm(data.SupportedSignatureAlgorithms, signature.signatureMethod());
             container.save();
             return new DigestDto
             {
@@ -91,9 +91,9 @@
                 { CryptoAlgorithm: "RSA", PaddingScheme: "PSS", HashFunction: "SHA-512" } => fragment == "#sha512-rsa-MGF1",
                 _ => false
             };
-        
+
         ~SigningService() => Dispose(false);
-        
+
         public void Dispose()
         {
             Dispose(true);
@@ -104,7 +104,8 @@
         {
             if (!_disposedValue)
             {
-                if (disposing) {
+                if (disposing)
+                {
                     // You can release managed resources here if needed.
                 }
 

--- a/src/WebEid.AspNetCore.Example/Signing/SigningService.cs
+++ b/src/WebEid.AspNetCore.Example/Signing/SigningService.cs
@@ -11,16 +11,23 @@
     using Microsoft.Extensions.Logging;
     using WebEid.Security.Util;
 
-    public class SigningService
+    public class SigningService : IDisposable
     {
         private static readonly string FileToSign = Path.Combine("wwwroot", "files", "example-for-signing.txt");
         private readonly DigiDocConfiguration configuration;
         private readonly ILogger logger;
+        private bool _disposedValue;
 
         public SigningService(DigiDocConfiguration configuration, ILogger logger)
         {
             this.configuration = configuration;
             this.logger = logger;
+            
+            // Current implementation of static digidoc assumes that SigningService is used as singleton
+            // in ASP.NET Core application we initialize it with AddSingleton method in Startup.cs
+            // digidoc is initialized in constructor and terminated in Dispose
+            configuration.Initialize();
+            digidoc.initialize("WebEidExample");
         }
 
         public DigestDto PrepareContainer(CertificateDto data, ClaimsIdentity identity, string tempContainerName)
@@ -31,49 +38,30 @@
                 throw new ArgumentException(
                     "Authenticated subject ID code differs from signing certificate subject ID code");
             }
-
-            configuration.Initialize();
-            digidoc.initialize("WebEidExample");
-            try
-            {
-                this.logger?.LogDebug("Creating container file: '{0}'", tempContainerName);
-                Container container = Container.create(tempContainerName);
-                container.addDataFile(FileToSign, "application/octet-stream");
-                logger?.LogInformation("Preparing container for signing for file '{0}'", tempContainerName);
-                var signature =
-                    container.prepareWebSignature(certificate.Export(X509ContentType.Cert), "time-stamp");
+            
+            this.logger?.LogDebug("Creating container file: '{0}'", tempContainerName);
+            Container container = Container.create(tempContainerName);
+            container.addDataFile(FileToSign, "application/octet-stream");
+            logger?.LogInformation("Preparing container for signing for file '{0}'", tempContainerName);
+            var signature =
+                container.prepareWebSignature(certificate.Export(X509ContentType.Cert), "time-stamp");
                 var hashFunction = GetSupportedHashAlgorithm(data.SupportedSignatureAlgorithms, signature.signatureMethod());
-                container.save();
-                return new DigestDto
-                {
-                    Hash = Convert.ToBase64String(signature.dataToSign()),
-                    HashFunction = hashFunction
-                };
-            }
-            finally
+            container.save();
+            return new DigestDto
             {
-                digidoc.terminate();
-            }
+                Hash = Convert.ToBase64String(signature.dataToSign()),
+                HashFunction = hashFunction
+            };
         }
-
 
         public void SignContainer(SignatureDto signatureDto, string tempContainerName)
         {
-            configuration.Initialize();
-            digidoc.initialize("WebEidExample");
-            try
-            {
-                var container = Container.open(tempContainerName);
-                var signatureBytes = Convert.FromBase64String(signatureDto.Signature);
-                var signature = container.signatures().First(); // Container must have one signature as it was added in PrepareContainer
-                signature.setSignatureValue(signatureBytes);
-                signature.extendSignatureProfile("BES/time-stamp");
-                container.save();
-            }
-            finally
-            {
-                digidoc.terminate();
-            }
+            var container = Container.open(tempContainerName);
+            var signatureBytes = Convert.FromBase64String(signatureDto.Signature);
+            var signature = container.signatures().First(); // Container must have one signature as it was added in PrepareContainer
+            signature.setSignatureValue(signatureBytes);
+            signature.extendSignatureProfile("BES/time-stamp");
+            container.save();
         }
 
         private static string GetSupportedHashAlgorithm(IList<SignatureAlgorithmDto> supportedSignatureAlgorithms, string signatureMethod)
@@ -103,5 +91,24 @@
                 { CryptoAlgorithm: "RSA", PaddingScheme: "PSS", HashFunction: "SHA-512" } => framgent == "#sha512-rsa-MGF1",
                 _ => false
             };
+        
+        ~SigningService() => Dispose(false);
+        
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (!_disposedValue)
+            {
+                if (disposing) {}
+
+                digidoc.terminate();
+                _disposedValue = true;
+            }
+        }
     }
 }


### PR DESCRIPTION
In fixed version digidoc is initialized in constructor and terminated in Dispose.  Problematic implementation initalized and terminated digidoc inside methods using digidoc which could cause race condition with multiple threads.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Please update Signed-off-by info and read the common contributing guidelines
before you continue https://github.com/web-eid/.github/blob/master/CONTRIBUTING.md!
-->

Signed-off-by: Villu Roogna <villu.roogna@gmail.com>
